### PR TITLE
Fix package link

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -14,7 +14,7 @@ GRAPH
   java (1.36.0)
     apt (>= 0.0.0)
   limits (1.0.0)
-  nifi (0.3.2)
+  nifi (0.3.3)
     apt (>= 0.0.0)
     ark (>= 0.0.0)
     java (>= 0.0.0)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Nifi
-This cookbook installs Nifi v0.4.0. For more details on Nifi installation, usage, and configuration best practices, check out the [Nifi Administration Guide](https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html).
+This cookbook installs Nifi v0.4.1. For more details on Nifi installation, usage, and configuration best practices, check out the [Nifi Administration Guide](https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html).
 
 ## Requirements
 ### depends

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,3 @@
-default['nifi']['package_url'] = 'http://apache.mirrors.tds.net/nifi/0.4.1/nifi-0.4.1-bin.tar.gz '
+default['nifi']['package_url'] = 'https://archive.apache.org/dist/nifi/0.4.1/nifi-0.4.1-bin.tar.gz'
 default['nifi']['version']     = '0.4.1'
 default['java']['jdk_version'] = '7'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'me@mercedescoyle.com'
 license          'all_rights'
 description      'Installs/Configures nifi'
 long_description 'Installs/Configures nifi'
-version          '0.3.2'
+version          '0.3.3'
 
 supports 'ubuntu'
 


### PR DESCRIPTION
We were pulling 0.4.1 from a broken mirror. This has been amended, and the README has been updated to reflect the fact that we install version 0.4.1